### PR TITLE
3 typos

### DIFF
--- a/MolecularDynamics.ipynb
+++ b/MolecularDynamics.ipynb
@@ -114,7 +114,7 @@
     "\n",
     "Eq. [](traj_sol) is extremely powerful. We now demonstrate how it can be used to derive numerical algorithms to solve the classical equations of motion. For simplicity, we will focus on a single particle in one dimension.\n",
     "\n",
-    "In principle, we if knew how to apply the classical propagator on the microstate vector, we would have solved the equations of motion for all times. For a single particle,\n",
+    "In principle, if we knew how to apply the classical propagator on the microstate vector, we would have solved the equations of motion for all times. For a single particle,\n",
     "\n",
     "$$\n",
     "i \\hat{L} = \\dot{q} \\frac{\\partial }{\\partial q} + \\dot{p} \\frac{\\partial }{\\partial p}  = \\frac{p}{m} \\frac{\\partial }{\\partial q} + F(q) \\frac{\\partial }{\\partial p}.\n",
@@ -574,7 +574,7 @@
     "\n",
     "`````\n",
     "\n",
-    "How large should be the main box so that the properties of the simulated system resemble the propoerties of a bulk liquid or solid? It depends on the interactions. If they are relatively short-ranged, then a small box may suffice. For the LJ potential, a box of side length $L=6\\sigma$ is usually sufficient. But for very long-range interaction, this is not the case and more sophisticated methdos are needed, of which we will not elaborate. In addition, this approach works when the fluctuations of the system in space are much smaller than the size of the box. So for the case of a gas-liquid phase transition, where the fluctuations are macroscopic (you can see the bubbles form!), this approach will not work. But for system far away from phase transitions and with short-range interactions, it is found to be highly succsessful.\n",
+    "How large should be the main box so that the properties of the simulated system resemble the propoerties of a bulk liquid or solid? It depends on the interactions. If they are relatively short-ranged, then a small box may suffice. For the LJ potential, a box of side length $L=6\\sigma$ is usually sufficient. But for very long-range interaction, this is not the case and more sophisticated methods are needed, of which we will not elaborate. In addition, this approach works when the fluctuations of the system in space are much smaller than the size of the box. So for the case of a gas-liquid phase transition, where the fluctuations are macroscopic (you can see the bubbles form!), this approach will not work. But for system far away from phase transitions and with short-range interactions, it is found to be highly succsessful.\n",
     "\n",
     "Finally, while periodic boundary conditions are great, they seem to have created a new problem. Now that we have infinitely many images of every particle, how are we to calculate the interaction between all of them? The practice is to overcome this problem by defining a spherical cutoff for the interaction for short-ranged potentials. One way to do it, is by implementing the **minimum image convention**. The minimum image convention states that for each particle $i$, you calculate the interaction only with the closest image of particle $j$. This is done similarly for testing for periodic boundary conditions, but instead of applying it on the position vector of each particle, you use the distances between the particles. The minimum image convention effectively introduces a spherical cutoff to the potential at a distance of half the box length."
    ]


### PR DESCRIPTION
1. closed parenthesis
2. methdos to methods
3. we if to if we